### PR TITLE
Add description on how to use the --serverhost for people who want to access lncli-web over a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Open your browser at the following address: [http://localhost:8280](http://local
 If you want to access `lncli-web` using a domain, add the `--serverhost` flag like so:
 
  ```
- node server --serverhost
+ node server --serverhost <yourdomain>
  ```
  Open your browser at the following addres:
  [http://yourdomain:8280](http://yourdomain:8280)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,15 @@ node server --help
 
 Open your browser at the following address: [http://localhost:8280](http://localhost:8280)
 
-Enjoy!
+If you want to access `lncli-web` using a domain, add the `--serverhost` flag like so:
+
+ ```
+ node server --serverhost
+ ```
+ Open your browser at the following addres:
+ [http://yourdomain:8280](http://yourdomain:8280)
+
+ Enjoy!
 
 
 ## Docker


### PR DESCRIPTION
Running `node server` allows you to access lncli-web using localhost, like so: [http://localhost:8280](http://localhost:8280). To access it through a domain, you need to add the `--serverhost` flag. This isn't immediately clear with the instructions provided. This commit adds that information on the README file