### PR TITLE
Perlover/macaroon option

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ program
 	.option("-p, --pwd [password]", "basic authentication password")
 	.option("-r, --limituser [login]", "basic authentication login for readonly account")
 	.option("-w, --limitpwd [password]", "basic authentication password for readonly account")
+	.option("-m, --macaroon-path [file path]", "path to admin.macaroon file")
 	.option("-f, --logfile [file path]", "path to file where to store the application logs")
 	.option("-e, --loglevel [level]", "level of logs to display (debug, info, warn, error)")
 	.option("-n, --lndlogfile <file path>", "path to lnd log file to send to browser")

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ program
 	.option("-p, --pwd [password]", "basic authentication password")
 	.option("-r, --limituser [login]", "basic authentication login for readonly account")
 	.option("-w, --limitpwd [password]", "basic authentication password for readonly account")
+	.option("-m, --macaroon-path [file path]", "path to admin.macaroon file")
 	.option("-f, --logfile [file path]", "path to file where to store the application logs")
 	.option("-e, --loglevel [level]", "level of logs to display (debug, info, warn, error)")
 	.option("-n, --lndlogfile <file path>", "path to lnd log file to send to browser")


### PR DESCRIPTION
Hello!

I am very need the option to define a path to macaroon 
I want to run two instances for testnet & mainnet
I found in your sources that your have everything excluding .option() for program object
I made patch and i have tested - it works
Can you merge this with master branch?

Thanks