### PR TITLE
Force a big num_max_events value for forwardingHistory

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -61,10 +61,13 @@ module.exports = function (app, lightning, db, config) {
   app.get('/api/lnd/pendingchannels', lightningRPCAdapter('pendingChannels'));
   app.get('/api/lnd/listpayments', lightningRPCAdapter('listPayments'));
   app.get('/api/lnd/listinvoices', lightningRPCAdapter('listInvoices'));
-  app.get('/api/lnd/forwardinghistory', lightningRPCAdapter('forwardingHistory'));
   app.get('/api/lnd/walletbalance', lightningRPCAdapter('walletBalance'));
   app.get('/api/lnd/channelbalance', lightningRPCAdapter('channelBalance'));
 
+  app.get('/api/lnd/forwardinghistory', lightningRPCAdapter('forwardingHistory', {
+    preHook: req => ({num_max_events: 100000 })
+  }));		
+	
   app.post('/api/lnd/getnodeinfo', lightningRPCAdapter('getNodeInfo', {
     preHook: req => ({ pub_key: req.body.pubkey }),
   }));


### PR DESCRIPTION
A call without any parameters to forwardingHistory returns only the first 100 items of the last one day period.

If you've forwarded more than 100 payments during a day, you can't see the last ones so this commit add a big value for the num_max_events parameters to get all the items of the day.

It's a temporary fix until lnd team fixes this weird implementation.