### PR TITLE
locked dockerfile to node 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:11
 
 EXPOSE 8280
 


### PR DESCRIPTION
Fix for #207. 

There is outdated dependency github.com/JoshKaufman/ursa not working on node 12+ (see https://github.com/JoshKaufman/ursa/issues/185).